### PR TITLE
limit user info width

### DIFF
--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -58,4 +58,5 @@ body {
 
 .user-info {
   min-width: 800px;
+  max-width: fit-content;
 }

--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -57,6 +57,5 @@ body {
 }
 
 .user-info {
-  min-width: 800px;
-  max-width: fit-content;
+  max-width: 414;
 }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Mobile users priofile-info is too far right on screen.

We limited the max width to fit content so that mobile users will have a more pleasent experience
